### PR TITLE
Fixed version of lintspaces

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "colors": "1.1.2",
     "commander": "2.9.0",
     "glob": "7.1.1",
-    "lintspaces": "0.5.0"
+    "lintspaces": "0.6.4"
   },
   "devDependencies": {
     "eslint": "3.17.1",


### PR DESCRIPTION
2 vulnerabilities required manual review and could not be updated
<img width="571" alt="Screen Shot 2020-02-16 at 21 54 22" src="https://user-images.githubusercontent.com/25826551/74620372-edd47980-5106-11ea-81be-9d10f59b3d01.png">
