### PR TITLE
Добавь скрипты для удобной публикации

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,21 +1,22 @@
-editorconfig-cli
-================
+# editorconfig-cli
 
 [![Vulnerabilities count][vulnerabilities-image]][vulnerabilities-url]
 
-Simple command line interface (CLI) for [.editorconfig](https://editorconfig.org) based on the node-lintspaces module. 
+Simple command line interface (CLI) for [.editorconfig](https://editorconfig.org) based on the node-lintspaces module.
+
 Uses `.editorconfig` by default from current directory. To change default location use `-e` argument.
 Supports [GLOB format](https://github.com/isaacs/node-glob).
 
 ## Install
-```
-$ npm install -g @htmlacademy/editorconfig-cli
-```
 
+```shell
+npm install -g @htmlacademy/editorconfig-cli
+```
 
 ## Help
-```
-zeckson@mac ~/d/editorconfig-cli (master)> editorconfig-cli --help                                                                                  19:20:07
+
+```shell
+$ editorconfig-cli --help
 
   Usage: editorconfig-cli [options] <file ... or 'glob'>
 
@@ -27,31 +28,32 @@ zeckson@mac ~/d/editorconfig-cli (master)> editorconfig-cli --help              
     -j, --json <file>                       load GLOBs from JSON file. If no input passed, then it tries to find array in package.json
     -x, --exclude <regexp>                  exclude files by pattern. Default 'normalize.*'
     -v, --verbose                           verbose output
-
 ```
 
 ## Example Commands
 
 Check all JavaScript files recursively, using `./.editorconfig` as settings:
 
-```
+```shell
 editorconfig-cli **/*.js
 ```
 
 The same as above but with [GLOB format](https://github.com/isaacs/node-glob):
 
-```
+```shell
 editorconfig-cli '**/*.js'
 ```
 
 Load GLOBs from `package.json` and exclude `normalize.*` by default:
-```
+
+```shell
 editorconfig-cli
 ```
 
 Format of JSON with GLOBs:
 
 File: `glob.json`
+
 ```json
 {
   "editorconfig-cli": [
@@ -67,16 +69,18 @@ File: `glob.json`
 ```
 
 Pass `glob.json` to CLI:
-```
+
+```shell
 editorconfig-cli -j glob.json
 ```
 
 ## Ignores
+
 lintspaces supports [built-in ignores](https://github.com/schorfES/node-lintspaces#ignores-option).
 
 Using built in ignores can be done like so:
 
-```
+```shell
 editorconfig-cli -i 'js-comments' -i 'c-comments'
 ```
 

--- a/package.json
+++ b/package.json
@@ -13,7 +13,10 @@
   "scripts": {
     "lint": "eslint index.js",
     "test": "node ./index.js",
-    "pretest": "npm run lint"
+    "pretest": "npm run lint",
+		"preversion": "npm run lint",
+		"postversion": "npm publish",
+		"postpublish": "git push origin --all; git push origin --tags"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -7,6 +7,9 @@
   "bin": {
     "editorconfig-cli": "./index.js"
   },
+  "files": [
+    "./index.js"
+  ],
   "scripts": {
     "lint": "eslint index.js",
     "test": "node ./index.js",


### PR DESCRIPTION
Пока пришлось в скрипт `preversion` вставить `npm run lint` вместо `npm run test`. Потому что сейчас тесты такие, что мы с ними в преверсионировании далеко не улетим — они просто запускают основной файл и показывают, что в корявых файлах всё коряво, прямо в виде ошибок.

Потом, когда и если написать нормальные тесты, можно будет заменить в этом скрипте `lint` на `test`. Ну а пока перед публикацией и просто eslint натравить на основной файл — уже хорошо, лучше, чем ничего 🤓