### PR TITLE
Fix warning not being properly identified to exit as error and color as red

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ import {resolve as pathResolve} from "node:path";
 import {inspect, format} from "node:util";
 
 import Validator from "lintspaces";
-import * as types from "lintspaces/src/constants/types.js";
+import {default as types} from "lintspaces/src/constants/types.js";
 import {program} from "commander";
 import {globby} from "globby";
 import picocolors from "picocolors";
@@ -82,8 +82,7 @@ const printReport = (report) => {
       for (const err of line) {
         const type = err.type;
 
-        // Change the harcoded "warning" to types.WARNING when import has been fixed
-        const isWarning = type.toLowerCase() === "warning";
+        const isWarning = type.toLowerCase() === types.WARNING;
         const typeColor = isWarning ? picocolors.red(type) : picocolors.yellow(type);
 
         if (isWarning) {

--- a/index.js
+++ b/index.js
@@ -82,7 +82,7 @@ const printReport = (report) => {
       for (const err of line) {
         const type = err.type;
 
-        const isWarning = err.type.toLowerCase() === types.WARNING;
+        const isWarning = type.toLowerCase() === types.WARNING;
         const typeColor = isWarning ? picocolors.red(type) : picocolors.yellow(type);
 
         if (isWarning) {

--- a/index.js
+++ b/index.js
@@ -82,7 +82,8 @@ const printReport = (report) => {
       for (const err of line) {
         const type = err.type;
 
-        const isWarning = type.toLowerCase() === types.WARNING;
+        // Change the harcoded "warning" to types.WARNING when import has been fixed
+        const isWarning = type.toLowerCase() === "warning";
         const typeColor = isWarning ? picocolors.red(type) : picocolors.yellow(type);
 
         if (isWarning) {


### PR DESCRIPTION
Since changing from require to import on all dependencies, the "types" import has been broken and thus it was comparing to undefined and never actually entering the `if` statement.

You can see `isWarning` is always false, because it also always prints them as yellow now, as opposed to the expected red. Wwe noticed this on jdm-contrib/jdm#1966 and have reverted to editorconfig-cli 1.0.0 in the meantime.

My fix is not the prettiest, but it works, a proper fix would be to fix the import, but I don't have the knowledge and/or time atm :'(

PS: I also think the importing of `Validator` might be working almost by chance